### PR TITLE
Pass required data map to ex-info on null error

### DIFF
--- a/src/mattsum/impl/boot_helpers.clj
+++ b/src/mattsum/impl/boot_helpers.clj
@@ -27,7 +27,7 @@
 (defn not-nil
   [msg obj]
   (when (nil? obj)
-    (throw (ex-info msg)))
+    (throw (ex-info msg {})))
   obj)
 
 (defn apply-replacements


### PR DESCRIPTION
Ran into this while trying to get stuff set up. I had a stray edn file for boot-cljs which was causing some issues, but I was getting an arity error on the call to `ex-info` instead of the message telling me which file was missing.