### PR TITLE
Fix after-cljsbuild single-letter option

### DIFF
--- a/src/mattsum/boot_react_native.clj
+++ b/src/mattsum/boot_react_native.clj
@@ -165,7 +165,7 @@ require('" boot-main "');
   [o output-dir OUT str  "The cljs :output-dir"
    a asset-path PATH str "The (optional) asset-path. Path relative to React Native app where main.js is stored."
    s server-url SERVE str "The (optional) IP address and port for the websocket server to listen on."
-   a app-dir OUT str  "The (relative) path to the React Native application"]
+   A app-dir OUT str  "The (relative) path to the React Native application"]
   (comp (react-native-devenv :output-dir output-dir
                           :asset-path asset-path
                           :server-url server-url)


### PR DESCRIPTION
Boot throws an assertion error that single-letter options need to be unique `(cli: options must be unique: a)`. This fix renames one of the options to disambiguate.