### PR TITLE
Move example test out of status bar on iOS

### DIFF
--- a/example/src/mattsum/simple_example/core.cljs
+++ b/example/src/mattsum/simple_example/core.cljs
@@ -18,7 +18,7 @@
 (defn root-view
   []
   [view
-   [text "CHANGE THIS: HELLO WORLD"]])
+   [text {:style {:margin-top 22, :margin-left 8}} "CHANGE THIS: HELLO WORLD"]])
 
 (defn mount-root []
   (reag/render [root-view] 1))


### PR DESCRIPTION
On iOS the example text collides with the status bar, making it hard to read:

![screen shot 2016-01-18 at 23 20 38](https://cloud.githubusercontent.com/assets/106328/12404295/879ee26c-be3a-11e5-8a1a-2651521ea14c.png)

This PR moves it out of the way. Haven't test this on Android.