### PR TITLE
Immediately mount root-view after start-up

### DIFF
--- a/example/app/index.ios.js
+++ b/example/app/index.ios.js
@@ -4,55 +4,5 @@
  */
 'use strict';
 
-var React = require('react-native');
-var {
-  AppRegistry,
-  StyleSheet,
-  Text,
-  View,
-} = React;
-
-var SimpleExampleApp = React.createClass({
-  render: function() {
-    return (
-      <View style={styles.container}>
-        <Text style={styles.welcome}>
-          Welcome to React Native!
-        </Text>
-        <Text style={styles.instructions}>
-          To get started, edit index.ios.js
-        </Text>
-        <Text style={styles.instructions}>
-          Press Cmd+R to reload,{'\n'}
-          Cmd+D or shake for dev menu
-        </Text>
-      </View>
-    );
-  }
-});
-
-var styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    justifyContent: 'center',
-    alignItems: 'center',
-    backgroundColor: '#F5FCFF',
-  },
-  welcome: {
-    fontSize: 20,
-    textAlign: 'center',
-    margin: 10,
-  },
-  instructions: {
-    textAlign: 'center',
-    color: '#333333',
-    marginBottom: 5,
-  },
-});
-
-AppRegistry.registerComponent('SimpleExampleApp', () => SimpleExampleApp);
-
-setTimeout(function(){
-    require('./build/main.js');
-    mattsum.simple_example.core.main();
-});
+require('./build/main.js');
+mattsum.simple_example.core.main();

--- a/example/src/mattsum/simple_example/core.cljs
+++ b/example/src/mattsum/simple_example/core.cljs
@@ -26,7 +26,9 @@
 (defn main
   []
   (js/console.log "MAIN")
-  (mount-root))
+  (.registerComponent js/React.AppRegistry
+                      "SimpleExampleApp"
+                      #(reag/reactify-component root-view)))
 
 (test/deftest testingt
   (test/is (= 1 2) "ERROR"))


### PR DESCRIPTION
Mount root-view on start-up, rather than showing intermediate view (on iOS). Moves react initialization to cljs.I think this simplifies things. What do you think, @mjmeintjes ?

Not tested on Android -- similar fix probably works there.

Also removes the warning: ```Warning: setState(...): Can only update a mounted or mounting component. This usually means you called setState() on an unmounted component. This is a no-op. Please check the code for the undefined component.reactConsoleError```