### PR TITLE
Fix android logging

### DIFF
--- a/example/build.boot
+++ b/example/build.boot
@@ -49,6 +49,7 @@
         (cljs :main "mattsum.simple-example.core")
         (rn/after-cljsbuild :server-url "localhost:8081")
         (if (= :ios platform) (rn/print-ios-log) identity)
+        (if (= :android platform) (rn/print-android-log) identity)
         (target :dir ["app/build"])
         ))
 

--- a/src/mattsum/boot_react_native.clj
+++ b/src/mattsum/boot_react_native.clj
@@ -184,12 +184,10 @@ require('" boot-main "');
                        ;; TODO: Support console.group? - will need support from JS side as well
                        (println line))]
     (c/with-pre-wrap fileset
-      (with-programs [adb]
-        (when (nil? @log-process)
-          (reset! log-process
-                  (adb "logcat" "-v" "time" "*:S" "ReactNative:V" "ReactNativeJS:V"
-                       {:out process-line})))
-        )
+      (when (nil? @log-process)
+        (reset! log-process
+          (util/sh "adb" "logcat" "-v" "time" "*:S" "ReactNative:V" "ReactNativeJS:V")))
+      
       fileset)))
 
 (deftask start-rn-packager


### PR DESCRIPTION
For me, this change is necessary to see any output from the android
logger.

In my experiments I found out that using conch for any process that
doesn't terminate would never print anything to the screen, So `(ls)`
would work fine but `(ping "www.google.com")` would never flush to the
screen, but just hang without printing forever:

<img width="371" alt="screen shot 2016-02-04 at 9 46 21 am" src="https://cloud.githubusercontent.com/assets/465987/12818651/bbd60e8c-cb25-11e5-84fa-f162a84f1d8f.png">

I made a note to research this more and see if I can determine the
problem before I submit a bug on the conch repo. It could possibly be
platform-specific, as I am on OS X.

Hopefully I can get this figured out and fixed so we could go back to
conch once the `process-line` functionality is done