### PR TITLE
Feature/better ios logs

### DIFF
--- a/build.boot
+++ b/build.boot
@@ -22,8 +22,10 @@
       :license {"Eclipse Public License"
                 "http://www.eclipse.org/legal/epl-v10.html"}})
 
-(deftask dev []
+(deftask dev
+  "Continuously build jar and install to local maven repository"
+  []
   (comp (watch)
-     (pom)
-     (jar)
-     (install)))
+        (pom)
+        (jar)
+        (install)))

--- a/example/build.boot
+++ b/example/build.boot
@@ -48,7 +48,7 @@
 
         (cljs :main "mattsum.simple-example.core")
         (rn/after-cljsbuild :server-url "localhost:8081")
-        (if (= :ios platform) (rn/print-ios-log) identity)
+        (if (= :ios platform) (rn/print-ios-log :grep "SimpleExampleApp") identity)
         (target :dir ["app/build"])
         ))
 

--- a/example/src/mattsum/simple_example/core.cljs
+++ b/example/src/mattsum/simple_example/core.cljs
@@ -25,6 +25,7 @@
 
 (defn main
   []
+  (enable-console-print!)
   (js/console.log "MAIN")
   (.registerComponent js/React.AppRegistry
                       "SimpleExampleApp"
@@ -35,7 +36,6 @@
 
 (defn on-js-reload
   []
-  (enable-console-print!)
   (test/run-tests)
   (js/console.log "JS RELOADING")
   (mount-root))

--- a/src/mattsum/boot_react_native.clj
+++ b/src/mattsum/boot_react_native.clj
@@ -274,10 +274,10 @@ require('" boot-main "');
 
 (deftask print-ios-log
   "Print iOS simulator log"
-  []
+  [g grep GREP str "Only print lines containg GREP, using fgrep(1). Defaults to printing all lines"]
   (let [!running (atom false)]
     (c/with-pre-wrap fileset
       (when-not @!running ;; make sure we run only once
         (reset! !running true)
-        (future (bh/tail-fn bh/newest-log)))
+        (future (bh/tail-fn bh/newest-log grep)))
       fileset)))

--- a/src/mattsum/boot_react_native.clj
+++ b/src/mattsum/boot_react_native.clj
@@ -275,9 +275,9 @@ require('" boot-main "');
 (deftask print-ios-log
   "Print iOS simulator log"
   []
-  (let [running (atom false)]
+  (let [!running (atom false)]
     (c/with-pre-wrap fileset
-      (when-not @running ;; make sure we run only once
-        (reset! running true)
-        (util/sh "tail" "-f" (bh/newest-log)))
+      (when-not @!running ;; make sure we run only once
+        (reset! !running true)
+        (future (bh/tail-fn bh/newest-log)))
       fileset)))

--- a/src/mattsum/impl/boot_helpers.clj
+++ b/src/mattsum/impl/boot_helpers.clj
@@ -197,24 +197,38 @@
            first
            .getPath))
 
+(defn ->grep [only]
+  (assert (string? only))
+  (assert (and (not (.contains only "'")) (not (.contains only "\\")))
+          "Search term must not contain special chars")
+  ["bash" "-c" (format  "\"$@\" | grep --line-buffered -F '%s'" only) "ignore-first-arg"])
+
+(defn tail-cmd [fname only]
+  (let [prefix (if only (->grep only) [])]
+    (concat prefix ["tail" "-0f" fname])))
+
 (defn tail-fn
   "Tails filename returned by newest-fn. Periodically checks is newest-fn
-  returns a different filename. If so, stops previous tail and tails new file."
-  [newest-fn]
-  (let [!proc (atom nil)]
-    (try
-      (loop [curr nil
-             fname (newest-fn)]
-        (when-not (= curr fname)
-          (when-let [proc @!proc]
-            (conch/destroy proc)
-            (reset! !proc nil))
-          (do
-            (println (str "Now tailing " fname "..."))
-            (reset! !proc (sh* "tail" "-0f" fname))))
-        (Thread/sleep 500)
-        (recur fname (newest-fn)))
-      (finally
-        (when-let [proc @!proc]
-          (conch/destroy proc)
-          (reset! !proc nil))))))
+  returns a different filename. If so, stops previous tail and tails new file.
+
+  If only is provided, filter output by grepping for that string."
+  ([newest-fn] (tail-fn newest-fn nil))
+  ([newest-fn only]
+   (let [!proc (atom nil)]
+     (try
+       (loop [curr nil
+              fname (newest-fn)]
+         (when-not (= curr fname)
+           (when-let [proc @!proc]
+             (conch/destroy proc)
+             (reset! !proc nil))
+           (do
+             (let [cmd (tail-cmd fname only)]
+               (util/info "Now tailing %s...\n" fname)
+               (reset! !proc (apply sh* cmd)))))
+         (Thread/sleep 500)
+         (recur fname (newest-fn)))
+       (finally
+         (when-let [proc @!proc]
+           (conch/destroy proc)
+           (reset! !proc nil)))))))


### PR DESCRIPTION
Improve log discovery and display on iOS simulator

Continuously look for and tail the newest iOS sim log file. Also add the ability to grep for string in logs. When used with application name, this narrows down log output to just the application logs.