### PR TITLE
Add boot.properties to example

### DIFF
--- a/example/boot.properties
+++ b/example/boot.properties
@@ -1,0 +1,5 @@
+#http://boot-clj.com
+BOOT_CLOJURE_NAME=org.clojure/clojure
+BOOT_VERSION=2.5.5
+BOOT_CLOJURE_VERSION=1.7.0
+BOOT_EMIT_TARGET=no


### PR DESCRIPTION
Ensures clojure 1.7.0 is used, so the cljs.repl namespace is present,
and suppresses the output of the target directory.

Closes #32