### PR TITLE
Note about disabling React Native's Live Reload

### DIFF
--- a/readme.org
+++ b/readme.org
@@ -42,6 +42,9 @@ There is an example in the example directory that illustrates this - here's the 
 Automatically reloads cljs files as you edit them. Better than normal React Native reloading because it keeps your application state, and just changes the behaviour.
 
 Hot reloading works in both Chrome Debug mode and normal mode. To enable reloading, just use [[https://github.com/adzerk-oss/boot-reload][boot-reload]].
+
+Remember to disable React Native's own live reload in the debug menu: ctrl-cmd-z. Otherwise it will always reload the whole app each time you change something.
+
 *** NRepl support
 Integrates with normal nrepl process:
  * Setup your build pipeline (see example app)


### PR DESCRIPTION
Added a note reminding the user to disable the built in Live Reload. Otherwise the whole app will reload each time. Empirically tested...