### PR TITLE
Run RN packager in a tmpdir

### DIFF
--- a/src/mattsum/boot_react_native.clj
+++ b/src/mattsum/boot_react_native.clj
@@ -244,7 +244,7 @@ require('" boot-main "');
       (let [in-file  (c/tmp-file tmp-file)
             relpath  (c/tmp-path tmp-file)
             out-file (io/file work-dir (str/replace relpath (str output-dir "/") ""))]
-        (util/info "... copying %s\n" in-file)
+        (util/dbug "... copying %s\n" in-file)
         (io/make-parents out-file)
         (bf/hard-link in-file out-file)))))
 

--- a/src/mattsum/boot_react_native.clj
+++ b/src/mattsum/boot_react_native.clj
@@ -370,7 +370,8 @@ require('" boot-main "');
                                "--platform" platform
                                "--dev" (str (boolean (not prod)))
                                "--entry-file" origin
-                               "--transformer" rn-transformer-relpath
+                               "--transformer" (.getAbsolutePath
+                                                (io/file rn-work-dir rn-transformer-relpath))
                                "--bundle-output" (.getAbsolutePath out)
                                "--sourcemap-output" (str (.getAbsolutePath out) ".map")
                                "--assets-dest" outd]]

--- a/src/mattsum/boot_react_native.clj
+++ b/src/mattsum/boot_react_native.clj
@@ -38,8 +38,10 @@
         ;; Create the output dir in outer context allows us to cache the
         ;; compilation, which means we don't have to re-parse each file
         tmp-dir        (c/tmp-dir!)
-        output-dir     (doto (io/file tmp-dir cljs-dir)
-                         io/make-parents)]
+        output-dir     (if cljs-dir
+                         (doto (io/file tmp-dir cljs-dir)
+                           io/make-parents)
+                         tmp-dir)]
     (with-pre-wrap fileset
       (let [get-hash-diff #(c/fileset-diff @previous-files % :hash)
 

--- a/src/mattsum/impl/boot_helpers.clj
+++ b/src/mattsum/impl/boot_helpers.clj
@@ -12,7 +12,6 @@
 
 (defn read-resource-
   [src]
-  (println "Reading resource - " src)
   (->> src io/resource slurp))
 
 ;; For some reason Clojure/boot doesn't like us reading from the jar file too often,
@@ -40,7 +39,6 @@
   the new fileset"
   ([fileset path modify-fn] (modify-file fileset path modify-fn {}))
   ([fileset path modify-fn replacements]
-   (println "Modifying " path " using " modify-fn)
    (let [tmp (c/tmp-dir!)
          out-file (make-absolute tmp path)]
      (let [base-file (->> path
@@ -143,7 +141,6 @@
 (defn add-cljs-require-to-edn-files
   [fileset ids ns]
   (let [tmp (c/tmp-dir!)]
-    (println "Found edn files - " (get-cljs-edn-files fileset ids))
     (doseq [edn-file (get-cljs-edn-files fileset ids)]
       (let [path (c/tmp-path edn-file)
             edn-file (c/tmp-file edn-file)
@@ -199,35 +196,6 @@
 
 (defn file-by-path [path fileset]
   (c/tmp-file (get (:tree fileset) path)))
-
-(defn copy-file [source-path dest-path]
-  (clojure.java.io/copy (clojure.java.io/file source-path) (clojure.java.io/file dest-path)))
-
-(defn bundle* [in outf outd]
-  (let [tempfname (str "nested/temp/" (java.util.UUID/randomUUID) ".js")
-        temppath (str "app/" tempfname)
-        tempdirf (->> temppath clojure.java.io/as-file .getParentFile)
-        cli (-> "app/node_modules/react-native/local-cli/cli.js"
-                java.io.File.
-                .getAbsolutePath)
-        dir (-> in .getAbsoluteFile .getParent)
-        fname (-> in .getAbsolutePath)]
-    (util/info "Bundling %s...\n" fname)
-    ;; create nested temp directory
-    ;; we need this in order to keep the react packager happy
-    (util/info "Creating temp dir: %s\n" (.getAbsolutePath tempdirf))
-    (.mkdirs tempdirf)
-    (copy-file fname temppath)
-    (binding [util/*sh-dir* "app"]
-      (try
-        (util/dosh "node" cli
-                   "bundle" "--platform" "ios"
-                   "--dev" "true"
-                   "--entry-file" tempfname
-                   "--bundle-output" (.getAbsolutePath outf)
-                   "--assets-dest" (.getAbsolutePath outd))
-        (finally
-          (util/dosh "rm" "-f" tempfname))))))
 
 (defn ->grep [only]
   (assert (string? only))


### PR DESCRIPTION
Rather than running the React Native packager in the appdir itself,
create a Boot tmpdir, copy the required node_modules into it, and run
the packager there.

By running from a tmpdir, we can construct exactly the directory
structure that the packager expects from a standard JavaScript
project without needing to structure the boot fileset that way. This
means we can play nicely with other boot tasks that the project might
define -- such as other CLJS builds in the same project (ie
non-React-Native code that shares a codebase with our React Native
code).