### PR TITLE
Restored console.group

### DIFF
--- a/resources/mattsum/boot_rn/js/goog_base.js
+++ b/resources/mattsum/boot_rn/js/goog_base.js
@@ -10,7 +10,7 @@ if (typeof global !== 'undefined') {
     //React Native throws error because it does not support group logging
     console.groupCollapsed = console.groupCollapsed || console.log;
     console.group = console.group || console.log;
-    console.groupEnd = function() {};
+    console.groupEnd = console.groupEnd || function() {};
 
     goog.provide = function(name) {
         if (goog.isProvided_(name)) {


### PR DESCRIPTION
For me `console.group` and `console.groupCollapsed` now works with React Native so this is now obsolete. Better be tested by someone else as well though.
